### PR TITLE
tinyiiod: change return types for {write,read} callbacks

### DIFF
--- a/example.c
+++ b/example.c
@@ -21,14 +21,14 @@
 #include <stdio.h>
 #include <string.h>
 
-static void read_data(char *buf, size_t len)
+static ssize_t read_data(char *buf, size_t len)
 {
-	fread(buf, 1, len, stdin);
+	return fread(buf, 1, len, stdin);
 }
 
-static void write_data(const char *buf, size_t len)
+static ssize_t write_data(const char *buf, size_t len)
 {
-	fwrite(buf, 1, len, stdout);
+	return fwrite(buf, 1, len, stdout);
 }
 
 static ssize_t read_attr(const char *device, const char *attr,

--- a/tinyiiod-private.h
+++ b/tinyiiod-private.h
@@ -21,11 +21,11 @@
 #include "tinyiiod.h"
 
 char tinyiiod_read_char(struct tinyiiod *iiod);
-void tinyiiod_read(struct tinyiiod *iiod, char *buf, size_t len);
+ssize_t tinyiiod_read(struct tinyiiod *iiod, char *buf, size_t len);
 ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len);
 
-void tinyiiod_write_char(struct tinyiiod *iiod, char c);
-void tinyiiod_write(struct tinyiiod *iiod, const char *data, size_t len);
+ssize_t tinyiiod_write_char(struct tinyiiod *iiod, char c);
+ssize_t tinyiiod_write(struct tinyiiod *iiod, const char *data, size_t len);
 void tinyiiod_write_string(struct tinyiiod *iiod, const char *str);
 void tinyiiod_write_value(struct tinyiiod *iiod, int value);
 

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -70,9 +70,9 @@ char tinyiiod_read_char(struct tinyiiod *iiod)
 	return c;
 }
 
-void tinyiiod_read(struct tinyiiod *iiod, char *buf, size_t len)
+ssize_t tinyiiod_read(struct tinyiiod *iiod, char *buf, size_t len)
 {
-	iiod->ops->read(buf, len);
+	return iiod->ops->read(buf, len);
 }
 
 ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
@@ -99,14 +99,14 @@ ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
 	return (ssize_t) i;
 }
 
-void tinyiiod_write_char(struct tinyiiod *iiod, char c)
+ssize_t tinyiiod_write_char(struct tinyiiod *iiod, char c)
 {
-	iiod->ops->write(&c, 1);
+	return iiod->ops->write(&c, 1);
 }
 
-void tinyiiod_write(struct tinyiiod *iiod, const char *data, size_t len)
+ssize_t tinyiiod_write(struct tinyiiod *iiod, const char *data, size_t len)
 {
-	iiod->ops->write(data, len);
+	return iiod->ops->write(data, len);
 }
 
 void tinyiiod_write_string(struct tinyiiod *iiod, const char *str)

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -33,10 +33,10 @@ struct tinyiiod;
 
 struct tinyiiod_ops {
 	/* Read from the input stream */
-	void (*read)(char *buf, size_t len);
+	ssize_t (*read)(char *buf, size_t len);
 
 	/* Write to the output stream */
-	void (*write)(const char *buf, size_t len);
+	ssize_t (*write)(const char *buf, size_t len);
 
 	ssize_t (*read_attr)(const char *device, const char *attr,
 			     char *buf, size_t len, bool debug);


### PR DESCRIPTION
This change breaks API a bit, but in many cases this should cause compiler
warnings. The read & write callbacks should return how much was
read/written, or an error if it occurs.

This should help the library be a little more robust, with the intent of
propagating error-codes, in such a way that they can be better interpreted,
by doing retries or failing completely.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>