### PR TITLE
libtinyiiod: Extend read functions

### DIFF
--- a/tinyiiod-private.h
+++ b/tinyiiod-private.h
@@ -42,8 +42,8 @@ void tinyiiod_do_open(struct tinyiiod *iiod, const char *device,
 		      size_t sample_size, uint32_t mask);
 void tinyiiod_do_close(struct tinyiiod *iiod, const char *device);
 
-void tinyiiod_do_readbuf(struct tinyiiod *iiod,
-			 const char *device, size_t bytes_count);
+int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
+			    const char *device, size_t bytes_count);
 
 int32_t tinyiiod_parse_string(struct tinyiiod *iiod, char *str);
 

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -186,8 +186,8 @@ void tinyiiod_do_close(struct tinyiiod *iiod, const char *device)
 	tinyiiod_write_value(iiod, ret);
 }
 
-void tinyiiod_do_readbuf(struct tinyiiod *iiod,
-			 const char *device, size_t bytes_count)
+int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
+			    const char *device, size_t bytes_count)
 {
 	int32_t ret;
 	char buf[256];
@@ -196,17 +196,16 @@ void tinyiiod_do_readbuf(struct tinyiiod *iiod,
 
 	ret = iiod->ops->get_mask(device, &mask);
 	if (ret < 0) {
-		tinyiiod_write_value(iiod, ret);
-		return;
+		return ret;
 	}
 
 	while(bytes_count) {
 		size_t bytes = bytes_count > sizeof(buf) ? sizeof(buf) : bytes_count;
 
-		ret = (int32_t) iiod->ops->read_data(device, buf, bytes);
+		ret = iiod->ops->read_data(device, buf, bytes);
 		tinyiiod_write_value(iiod, ret);
 		if (ret < 0)
-			return;
+			return ret;
 
 		if (print_mask) {
 			char buf_mask[10];
@@ -219,4 +218,6 @@ void tinyiiod_do_readbuf(struct tinyiiod *iiod,
 		tinyiiod_write(iiod, buf, (size_t) ret);
 		bytes_count -= (size_t) ret;
 	}
+
+	return ret;
 }

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -77,6 +77,9 @@ ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
 	int32_t i;
 	bool found = false;
 
+	if (iiod->ops->read_line)
+		return iiod->ops->read_line(buf, len);
+
 	for (i = 0; i < len - 1; i++) {
 		buf[i] = tinyiiod_read_char(iiod);
 

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -146,8 +146,8 @@ void tinyiiod_do_read_attr(struct tinyiiod *iiod, const char *device,
 
 	tinyiiod_write_value(iiod, (int32_t) ret);
 	if (ret > 0) {
-		tinyiiod_write(iiod, buf, (size_t) ret);
-		tinyiiod_write_char(iiod, '\n');
+		buf[ret] = '\n';
+		tinyiiod_write(iiod, buf, (size_t) ret + 1);
 	}
 }
 

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -193,6 +193,7 @@ int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 	char buf[256];
 	uint32_t mask;
 	bool print_mask = true;
+	size_t offset = 0;
 
 	ret = iiod->ops->get_mask(device, &mask);
 	if (ret < 0) {
@@ -202,7 +203,8 @@ int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 	while(bytes_count) {
 		size_t bytes = bytes_count > sizeof(buf) ? sizeof(buf) : bytes_count;
 
-		ret = iiod->ops->read_data(device, buf, bytes);
+		ret = (int) iiod->ops->read_data(device, buf, offset, bytes);
+		offset += bytes;
 		tinyiiod_write_value(iiod, ret);
 		if (ret < 0)
 			return ret;

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -199,7 +199,8 @@ int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 	if (ret < 0) {
 		return ret;
 	}
-
+	if (iiod->ops->capture_data)
+		ret = iiod->ops->capture_data(device, bytes_count);
 	while(bytes_count) {
 		size_t bytes = bytes_count > sizeof(buf) ? sizeof(buf) : bytes_count;
 

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -45,7 +45,7 @@ struct tinyiiod_ops {
 	int32_t (*open)(const char *device, size_t sample_size, uint32_t mask);
 	int32_t (*close)(const char *device);
 
-
+	ssize_t (*capture_data)(const char *device, size_t bytes_count);
 	ssize_t (*read_data)(const char *device, char *buf, size_t offset,
 			     size_t bytes_count);
 

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -45,7 +45,9 @@ struct tinyiiod_ops {
 	int32_t (*open)(const char *device, size_t sample_size, uint32_t mask);
 	int32_t (*close)(const char *device);
 
-	ssize_t (*read_data)(const char *device, char *buf, size_t bytes_count);
+
+	ssize_t (*read_data)(const char *device, char *buf, size_t offset,
+			     size_t bytes_count);
 
 	int32_t (*get_mask)(const char *device, uint32_t *mask);
 };

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -29,6 +29,8 @@ struct tinyiiod_ops {
 	/* Write to the output stream */
 	ssize_t (*write)(const char *buf, size_t len);
 
+	ssize_t (*read_line)(char *buf, size_t len);
+
 	ssize_t (*read_attr)(const char *device, const char *attr,
 			     char *buf, size_t len, bool debug);
 	ssize_t (*write_attr)(const char *device, const char *attr,


### PR DESCRIPTION
tinyiiod_read_line() - It is not efficient, to read single characters over
network interface. Read data in a single shoot.

tinyiiod_do_read_attr() - send response into one message

tinyiiod_do_readbuf() - "capture()" function must be called once, before
data is read in the while loop.

Add return values for functions and check for success.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>