### PR TITLE
Extend ltinyiiod

### DIFF
--- a/tinyiiod-private.h
+++ b/tinyiiod-private.h
@@ -42,6 +42,10 @@ void tinyiiod_do_open(struct tinyiiod *iiod, const char *device,
 		      size_t sample_size, uint32_t mask);
 void tinyiiod_do_close(struct tinyiiod *iiod, const char *device);
 
+int32_t tinyiiod_do_open_instance(struct tinyiiod *iiod);
+
+int32_t tinyiiod_do_close_instance(struct tinyiiod *iiod);
+
 int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 			    const char *device, size_t bytes_count);
 

--- a/tinyiiod-private.h
+++ b/tinyiiod-private.h
@@ -45,6 +45,9 @@ void tinyiiod_do_close(struct tinyiiod *iiod, const char *device);
 int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 			    const char *device, size_t bytes_count);
 
+int32_t tinyiiod_do_writebuf(struct tinyiiod *iiod, const char *device,
+			     size_t bytes_count);
+
 int32_t tinyiiod_parse_string(struct tinyiiod *iiod, char *str);
 
 #endif /* TINYIIOD_PRIVATE_H */

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -199,8 +199,8 @@ int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 	if (ret < 0) {
 		return ret;
 	}
-	if (iiod->ops->capture_data)
-		ret = iiod->ops->capture_data(device, bytes_count);
+	if (iiod->ops->transfer_dev_to_mem)
+		ret = iiod->ops->transfer_dev_to_mem(device, bytes_count);
 	while(bytes_count) {
 		size_t bytes = bytes_count > sizeof(buf) ? sizeof(buf) : bytes_count;
 

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -186,6 +186,16 @@ void tinyiiod_do_close(struct tinyiiod *iiod, const char *device)
 	tinyiiod_write_value(iiod, ret);
 }
 
+int32_t tinyiiod_do_open_instance(struct tinyiiod *iiod)
+{
+	return iiod->ops->open_instance();
+}
+
+int32_t tinyiiod_do_close_instance(struct tinyiiod *iiod)
+{
+	return iiod->ops->close_instance();
+}
+
 int32_t tinyiiod_do_writebuf(struct tinyiiod *iiod,
 			     const char *device, size_t bytes_count)
 {

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -238,7 +238,7 @@ int32_t tinyiiod_do_readbuf(struct tinyiiod *iiod,
 	}
 	if (iiod->ops->transfer_dev_to_mem)
 		ret = iiod->ops->transfer_dev_to_mem(device, bytes_count);
-	while(bytes_count) {
+	while (bytes_count) {
 		size_t bytes = bytes_count > sizeof(buf) ? sizeof(buf) : bytes_count;
 
 		ret = (int) iiod->ops->read_data(device, buf, offset, bytes);

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -49,6 +49,10 @@ struct tinyiiod_ops {
 	ssize_t (*read_data)(const char *device, char *buf, size_t offset,
 			     size_t bytes_count);
 
+	ssize_t (*transfer_mem_to_dev)(const char *device, size_t bytes_count);
+	ssize_t (*write_data)(const char *device, const char *buf, size_t offset,
+			      size_t bytes_count);
+
 	int32_t (*get_mask)(const char *device, uint32_t *mask);
 };
 

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -45,7 +45,7 @@ struct tinyiiod_ops {
 	int32_t (*open)(const char *device, size_t sample_size, uint32_t mask);
 	int32_t (*close)(const char *device);
 
-	ssize_t (*capture_data)(const char *device, size_t bytes_count);
+	ssize_t (*transfer_dev_to_mem)(const char *device, size_t bytes_count);
 	ssize_t (*read_data)(const char *device, char *buf, size_t offset,
 			     size_t bytes_count);
 

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -28,8 +28,11 @@ struct tinyiiod_ops {
 
 	/* Write to the output stream */
 	ssize_t (*write)(const char *buf, size_t len);
-
 	ssize_t (*read_line)(char *buf, size_t len);
+
+	ssize_t (*open_instance)();
+
+	ssize_t (*close_instance)();
 
 	ssize_t (*read_attr)(const char *device, const char *attr,
 			     char *buf, size_t len, bool debug);


### PR DESCRIPTION
Extend libtinyiiod: 

- Add `tintiiod_do_writebuf()` function, that allows us to write to the device.
- Handle multiple instances, when more then one client is connected to the board, trough network interface.