### PR TITLE
tinyiiod: free tinyiiod "xml" and "ops" elements

### DIFF
--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -20,13 +20,13 @@
 #include "compat.h"
 
 struct tinyiiod {
-	const char *xml;
-	const struct tinyiiod_ops *ops;
+	char *xml;
+	struct tinyiiod_ops *ops;
 	char *buf;
 };
 
-struct tinyiiod * tinyiiod_create(const char *xml,
-				  const struct tinyiiod_ops *ops)
+struct tinyiiod * tinyiiod_create(char *xml,
+				  struct tinyiiod_ops *ops)
 {
 	struct tinyiiod *iiod = malloc(sizeof(*iiod));
 
@@ -42,6 +42,8 @@ struct tinyiiod * tinyiiod_create(const char *xml,
 
 void tinyiiod_destroy(struct tinyiiod *iiod)
 {
+	free(iiod->xml);
+	free(iiod->ops);
 	free(iiod->buf);
 	free(iiod);
 }

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -61,8 +61,8 @@ struct tinyiiod_ops {
 	int32_t (*set_timeout)(uint32_t timeout);
 };
 
-struct tinyiiod * tinyiiod_create(const char *xml,
-				  const struct tinyiiod_ops *ops);
+struct tinyiiod * tinyiiod_create(char *xml,
+				  struct tinyiiod_ops *ops);
 void tinyiiod_destroy(struct tinyiiod *iiod);
 int32_t tinyiiod_read_command(struct tinyiiod *iiod);
 


### PR DESCRIPTION
Remove const qualifier for "xml" and "ops" elements so that free operation
can be done.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>