### PR TITLE
tinyiiod: Fix readline function.

### DIFF
--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -86,7 +86,7 @@ ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
 	for (i = 0; i < len - 1; i++) {
 		buf[i] = tinyiiod_read_char(iiod);
 
-		if (buf[i] != '\n' && buf[i] != '\r')
+		if (buf[i] != '\n')
 			found = true;
 		else if (found)
 			break;
@@ -97,7 +97,7 @@ ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
 		return -EIO;
 	}
 
-	buf[i] = '\0';
+	buf[i - 1] = '\0';
 
 	return i;
 }


### PR DESCRIPTION
A command is terminated by a "\r\n", so read both characters and set "\r"
to "\0" to terminate a C string.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>