### PR TITLE
parser: Fix return value for "tinyiiod_parse_string" when "GETTRIG".

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -207,7 +207,7 @@ int32_t tinyiiod_parse_string(struct tinyiiod *iiod, char *str)
 		return tinyiiod_do_close_instance(iiod);
 
 	if (!strncmp(str, "GETTRIG", sizeof("GETTRIG") - 1))
-		tinyiiod_write_value(iiod, -ENODEV);
+		return tinyiiod_write_value(iiod, -ENODEV);
 
 	return -EINVAL;
 }


### PR DESCRIPTION
This was causing the network communication, to go into a undefined state.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>