### PR TITLE
compat.h: Added missing defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# libtinyiiod
+
+Tiny IIO Daemon Library

--- a/compat.h
+++ b/compat.h
@@ -44,9 +44,13 @@ typedef int bool;
 
 #define NULL (void*)0
 
-#define EIO 5	/* I/O error */
+#define ENOENT		2	/* No such file or directory */
+#define EIO		5	/* I/O error */
+#define ENODEV		19	/* No such device */
 #define EINVAL		22	/* Invalid argument */
+#define ENOSYS		38	/* Function not implemented */
 
+#define PRIi32		"li"
 # define PRIx32		"x"
 # define PRIu16		"u"
 #endif //_USE_STD_INT_TYPES

--- a/example.c
+++ b/example.c
@@ -82,16 +82,6 @@ static ssize_t ch_write_attr(const char *device, const char *channel,
 	return -ENOSYS;
 }
 
-static const struct tinyiiod_ops ops = {
-	.read = read_data,
-	.write = write_data,
-
-	.read_attr = read_attr,
-	.write_attr = write_attr,
-	.ch_read_attr = ch_read_attr,
-	.ch_write_attr = ch_write_attr,
-};
-
 static const char * const xml =
 	"<?xml version=\"1.0\" encoding=\"utf-8\"?><!DOCTYPE context [<!ELEMENT context "
 	"(device)*><!ELEMENT device (channel | attribute | debug-attribute)*><!ELEMENT "
@@ -113,6 +103,28 @@ static const char * const xml =
 	"<debug-attribute name=\"direct_reg_access\" />"
 	"</device></context>";
 
+static ssize_t get_xml(char **outxml)
+{
+
+	*outxml = calloc(1, strlen(xml) + 1);
+	if (!(*outxml))
+		return -ENOMEM;
+	memcpy(*outxml, xml, strlen(xml));
+
+	return 0;
+}
+
+static const struct tinyiiod_ops ops = {
+	.read = read_data,
+	.write = write_data,
+
+	.read_attr = read_attr,
+	.write_attr = write_attr,
+	.ch_read_attr = ch_read_attr,
+	.ch_write_attr = ch_write_attr,
+	.get_xml = get_xml,
+};
+
 static bool stop;
 
 static void set_handler(int32_t signal_nb, void (*handler)(int32_t))
@@ -130,7 +142,7 @@ static void quit_all(int32_t sig)
 
 int32_t main(void)
 {
-	struct tinyiiod *iiod = tinyiiod_create(xml, &ops);
+	struct tinyiiod *iiod = tinyiiod_create(&ops);
 
 	set_handler(SIGHUP, &quit_all);
 	set_handler(SIGPIPE, &quit_all);

--- a/parser.c
+++ b/parser.c
@@ -207,7 +207,7 @@ int32_t tinyiiod_parse_string(struct tinyiiod *iiod, char *str)
 		return tinyiiod_do_close_instance(iiod);
 
 	if (!strncmp(str, "GETTRIG", sizeof("GETTRIG") - 1))
-		tinyiiod_write_value(iiod, -ENODEV);
+		return tinyiiod_write_value(iiod, -ENODEV);
 
 	return -EINVAL;
 }

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -88,7 +88,7 @@ ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
 	for (i = 0; i < len - 1; i++) {
 		buf[i] = tinyiiod_read_char(iiod);
 
-		if (buf[i] != '\n' && buf[i] != '\r')
+		if (buf[i] != '\n')
 			found = true;
 		else if (found)
 			break;
@@ -99,7 +99,7 @@ ssize_t tinyiiod_read_line(struct tinyiiod *iiod, char *buf, size_t len)
 		return -EIO;
 	}
 
-	buf[i] = '\0';
+	buf[i - 1] = '\0';
 
 	return i;
 }

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -20,13 +20,11 @@
 #include "compat.h"
 
 struct tinyiiod {
-	char *xml;
 	struct tinyiiod_ops *ops;
 	char *buf;
 };
 
-struct tinyiiod * tinyiiod_create(char *xml,
-				  struct tinyiiod_ops *ops)
+struct tinyiiod * tinyiiod_create(struct tinyiiod_ops *ops)
 {
 	struct tinyiiod *iiod = malloc(sizeof(*iiod));
 
@@ -34,7 +32,6 @@ struct tinyiiod * tinyiiod_create(char *xml,
 		return NULL;
 
 	iiod->buf = malloc(IIOD_BUFFER_SIZE);
-	iiod->xml = xml;
 	iiod->ops = ops;
 
 	return iiod;
@@ -42,7 +39,6 @@ struct tinyiiod * tinyiiod_create(char *xml,
 
 void tinyiiod_destroy(struct tinyiiod *iiod)
 {
-	free(iiod->xml);
 	free(iiod->ops);
 	free(iiod->buf);
 	free(iiod);
@@ -129,11 +125,14 @@ ssize_t tinyiiod_write_value(struct tinyiiod *iiod, int32_t value)
 
 void tinyiiod_write_xml(struct tinyiiod *iiod)
 {
-	size_t len = strlen(iiod->xml);
+	char *xml;
+	iiod->ops->get_xml(&xml);
+	size_t len = strlen(xml);
 
 	tinyiiod_write_value(iiod, len);
-	tinyiiod_write(iiod, iiod->xml, len);
+	tinyiiod_write(iiod, xml, len);
 	tinyiiod_write_char(iiod, '\n');
+	free(xml);
 }
 
 void tinyiiod_do_read_attr(struct tinyiiod *iiod, const char *device,

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -59,10 +59,11 @@ struct tinyiiod_ops {
 	int32_t (*get_mask)(const char *device, uint32_t *mask);
 
 	int32_t (*set_timeout)(uint32_t timeout);
+
+	ssize_t (*get_xml)(char **outxml);
 };
 
-struct tinyiiod * tinyiiod_create(char *xml,
-				  struct tinyiiod_ops *ops);
+struct tinyiiod * tinyiiod_create(struct tinyiiod_ops *ops);
 void tinyiiod_destroy(struct tinyiiod *iiod);
 int32_t tinyiiod_read_command(struct tinyiiod *iiod);
 


### PR DESCRIPTION
Removed compiler errors caused by missing defines.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>