### PR TITLE
example: Fix build

### DIFF
--- a/example.c
+++ b/example.c
@@ -114,7 +114,7 @@ static ssize_t get_xml(char **outxml)
 	return 0;
 }
 
-static const struct tinyiiod_ops ops = {
+static struct tinyiiod_ops ops = {
 	.read = read_data,
 	.write = write_data,
 


### PR DESCRIPTION
libtinyiiod/example.c:145:42: warning: passing argument 1 of ‘tinyiiod_create’
discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  struct tinyiiod *iiod = tinyiiod_create(&ops);
                                          ^~~~

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>