### PR TITLE
libtinyiiod: Dual License LGPL-2.1-or-later OR ADI-BSD 5 clause

### DIFF
--- a/LICENSE_ADIBSD
+++ b/LICENSE_ADIBSD
@@ -1,0 +1,33 @@
+
+Copyright 2011(c) Analog Devices, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    - Neither the name of Analog Devices, Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    - The use of this software may or may not infringe the patent rights
+      of one or more patent holders.  This license does not release you
+      from the requirement that you obtain separate licenses from these
+      patent holders to use this software.
+    - Use of the software either in source or binary form, must be run
+      on or directly connected to an Analog Devices Inc. component.
+   
+THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.
+
+IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, INTELLECTUAL PROPERTY
+RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF 
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # libtinyiiod
 
 Tiny IIO Daemon Library
+
+## License
+
+This work is dual-licensed under the ADI-BSD License and GNU Lesser General Public License v2.1 (or later).
+You can choose between one of them if you use this work.
+
+`SPDX-License-Identifier: LGPL-2.1-or-later`
+
+ * [LICENSE_ADIBSD](../master/LICENSE_ADIBSD)
+
+ * [LICENSE_LGPL](../master/LICENSE)


### PR DESCRIPTION
This work is dual-licensed under the ADI-BSD License and GNU Lesser General Public License v2.1 (or later).
You can choose between one of them if you use this work.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>