### PR TITLE
libtinyiiod: Add support for operations on buffer attributes.

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -22,7 +22,8 @@
 static int32_t parse_rw_string(struct tinyiiod *iiod, char *str, bool write)
 {
 	char *device, *channel, *attr, *ptr;
-	bool is_channel = false, output = false, debug = false;
+	bool is_channel = false, output = false;
+	enum iio_attr_type type = IIO_ATTR_TYPE_DEVICE;
 	long bytes;
 
 	ptr = strchr(str, ' ');
@@ -41,8 +42,11 @@ static int32_t parse_rw_string(struct tinyiiod *iiod, char *str, bool write)
 		output = true;
 		str += sizeof("OUTPUT ") - 1;
 	} else if (!strncmp(str, "DEBUG ", sizeof("DEBUG ") - 1)) {
-		debug = true;
+		type = IIO_ATTR_TYPE_DEBUG;
 		str += sizeof("DEBUG ") - 1;
+	} else if (!strncmp(str, "BUFFER ", sizeof("BUFFER ") - 1)) {
+		type = IIO_ATTR_TYPE_BUFFER;
+		str += sizeof("BUFFER ") - 1;
 	}
 
 	if (is_channel) {
@@ -68,7 +72,7 @@ static int32_t parse_rw_string(struct tinyiiod *iiod, char *str, bool write)
 		str = ptr + 1;
 	} else {
 		tinyiiod_do_read_attr(iiod, device, channel,
-				      output, attr, debug);
+				      output, attr, type);
 		return 0;
 	}
 
@@ -77,7 +81,7 @@ static int32_t parse_rw_string(struct tinyiiod *iiod, char *str, bool write)
 		return -EINVAL;
 
 	tinyiiod_do_write_attr(iiod, device, channel,
-			       output, attr, (size_t) bytes, debug);
+			       output, attr, (size_t) bytes, type);
 
 	return 0;
 }

--- a/tinyiiod-private.h
+++ b/tinyiiod-private.h
@@ -32,11 +32,11 @@ ssize_t tinyiiod_write_value(struct tinyiiod *iiod, int32_t value);
 void tinyiiod_write_xml(struct tinyiiod *iiod);
 
 void tinyiiod_do_read_attr(struct tinyiiod *iiod, const char *device,
-			   const char *channel, bool ch_out, const char *attr, bool debug);
+			   const char *channel, bool ch_out, const char *attr, enum iio_attr_type type);
 
 void tinyiiod_do_write_attr(struct tinyiiod *iiod, const char *device,
 			    const char *channel, bool ch_out, const char *attr,
-			    size_t bytes, bool debug);
+			    size_t bytes, enum iio_attr_type type);
 
 void tinyiiod_do_open(struct tinyiiod *iiod, const char *device,
 		      size_t sample_size, uint32_t mask);

--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -134,7 +134,7 @@ void tinyiiod_write_xml(struct tinyiiod *iiod)
 }
 
 void tinyiiod_do_read_attr(struct tinyiiod *iiod, const char *device,
-			   const char *channel, bool ch_out, const char *attr, bool debug)
+			   const char *channel, bool ch_out, const char *attr, enum iio_attr_type type)
 {
 	ssize_t ret;
 
@@ -143,7 +143,7 @@ void tinyiiod_do_read_attr(struct tinyiiod *iiod, const char *device,
 					      ch_out, attr, iiod->buf, IIOD_BUFFER_SIZE);
 	else
 		ret = iiod->ops->read_attr(device, attr,
-					   iiod->buf, IIOD_BUFFER_SIZE, debug);
+					   iiod->buf, IIOD_BUFFER_SIZE, type);
 
 	tinyiiod_write_value(iiod, (int32_t) ret);
 	if (ret > 0) {
@@ -154,7 +154,7 @@ void tinyiiod_do_read_attr(struct tinyiiod *iiod, const char *device,
 
 void tinyiiod_do_write_attr(struct tinyiiod *iiod, const char *device,
 			    const char *channel, bool ch_out, const char *attr,
-			    size_t bytes, bool debug)
+			    size_t bytes, enum iio_attr_type type)
 {
 	ssize_t ret;
 
@@ -168,7 +168,7 @@ void tinyiiod_do_write_attr(struct tinyiiod *iiod, const char *device,
 		ret = iiod->ops->ch_write_attr(device, channel, ch_out,
 					       attr, iiod->buf, bytes);
 	else
-		ret = iiod->ops->write_attr(device, attr, iiod->buf, bytes, debug);
+		ret = iiod->ops->write_attr(device, attr, iiod->buf, bytes, type);
 
 	tinyiiod_write_value(iiod, (int32_t) ret);
 }

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -22,6 +22,12 @@
 
 struct tinyiiod;
 
+enum iio_attr_type {
+	IIO_ATTR_TYPE_DEVICE = 0,
+	IIO_ATTR_TYPE_DEBUG = 1,
+	IIO_ATTR_TYPE_BUFFER = 2,
+};
+
 struct tinyiiod_ops {
 	/* Read from the input stream */
 	ssize_t (*read)(char *buf, size_t len);
@@ -35,9 +41,9 @@ struct tinyiiod_ops {
 	ssize_t (*close_instance)();
 
 	ssize_t (*read_attr)(const char *device, const char *attr,
-			     char *buf, size_t len, bool debug);
+			     char *buf, size_t len, enum iio_attr_type type);
 	ssize_t (*write_attr)(const char *device, const char *attr,
-			      const char *buf, size_t len, bool debug);
+			      const char *buf, size_t len, enum iio_attr_type type);
 
 	ssize_t (*ch_read_attr)(const char *device, const char *channel,
 				bool ch_out, const char *attr, char *buf, size_t len);


### PR DESCRIPTION
Handle the read and write operations for all types of device attributes:
- device attribute
- debug attribute
- buffer attribute

Update the example.