### PR TITLE
compat.h: Define ssize_t for ARM Compiler.

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__ARMCC_VERSION)
 #ifndef _SSIZE_T_DEFINED
 #define _SSIZE_T_DEFINED
 #undef ssize_t


### PR DESCRIPTION
Added specific definition of ssize_t for arm compiler. 

This is effort for using no-OS repository as it is related to the pull request:
https://github.com/analogdevicesinc/no-OS/pull/964 

Signed-off-by: Pratyush Mallick <Pratyush.Mallick@analog.com>