### PR TITLE
tinyiiod.c: Fix writebuf

### DIFF
--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -219,8 +219,10 @@ int32_t tinyiiod_do_writebuf(struct tinyiiod *iiod,
 			if (ret < 0)
 				return ret;
 			bytes_count -= ret;
-		} else
+		} else if (ret < 0) {
 			return ret;
+		}
+		/* If ret == 0 -> no data available yet */
 	}
 	if (iiod->ops->transfer_mem_to_dev) {
 		ret = iiod->ops->transfer_mem_to_dev(device, total_bytes);


### PR DESCRIPTION
tinyiiod_read may return 0, which will mean that no data
is available. If so, try again until data is available and
no error code

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>