### PR TITLE
Minor updates to fix the build issue using IAR compiler. 

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <string.h>
 
-#if defined(_WIN32) || defined(__ARMCC_VERSION)
+#if defined(_WIN32) || defined(__ARMCC_VERSION) || defined(__IAR_SYSTEMS_ICC__)
 #ifndef _SSIZE_T_DEFINED
 #define _SSIZE_T_DEFINED
 #undef ssize_t

--- a/tinyiiod.h
+++ b/tinyiiod.h
@@ -26,7 +26,7 @@
 #else
 #define TINYIIOD_API __declspec(dllimport)
 #endif
-#elif __GNUC__ >= 4
+#elif (__GNUC__ >= 4) || defined(__IAR_SYSTEMS_ICC__)
 #define TINYIIOD_API
 #endif
 


### PR DESCRIPTION
1. ssize_t type unavailable in IAR standard libraries
2. TINYIIOD_API type undeclared in IAR

Signed-off-by: mahphalke <Mahesh.Phalke@analog.com>