### PR TITLE
tinyiiod.c: Do not write error code inside read_command.

### DIFF
--- a/tinyiiod.c
+++ b/tinyiiod.c
@@ -56,11 +56,7 @@ int32_t tinyiiod_read_command(struct tinyiiod *iiod)
 	if (ret < 0)
 		return ret;
 
-	ret = tinyiiod_parse_string(iiod, buf);
-	if (ret < 0)
-		tinyiiod_write_value(iiod, ret);
-
-	return ret;
+	return tinyiiod_parse_string(iiod, buf);
 }
 
 ssize_t tinyiiod_read(struct tinyiiod *iiod, char *buf, size_t len)


### PR DESCRIPTION
Each command handles individually the error code.
By writing it again in tinyiiod_read_command (the error code is written twice),
the integrity of the socket data is corrupted and the second error code is
transferred to the next command.

Signed-off-by: Teo Perisanu <Teo.Perisanu@analog.com>