### PR TITLE
parser: fix version string format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ LDFLAGS = -L $(LIB_DIR)							\
 	  -ltinyiiod
 IIO_DEFS = -D TINYIIOD_VERSION_MAJOR=$(TINYIIOD_VERSION_MAJOR)		\
 	   -D TINYIIOD_VERSION_MINOR=$(TINYIIOD_VERSION_MINOR)		\
-	   -D TINYIIOD_VERSION_GIT=0x$(shell git rev-parse --short HEAD)\
+	   -D TINYIIOD_VERSION_GIT=\"$(shell git rev-parse --short HEAD)\"\
 	   -D IIOD_BUFFER_SIZE=$(BUFF_SIZE)
 
 ifeq (true,$(strip $(STD_TYPES)))

--- a/parser.c
+++ b/parser.c
@@ -229,7 +229,7 @@ int32_t tinyiiod_parse_string(struct tinyiiod *iiod, char *str)
 	if (!strncmp(str, "VERSION", sizeof("VERSION"))) {
 		char buf[32];
 
-		snprintf(buf, sizeof(buf), "%"PRIu16".%"PRIu16".%07x\n",
+		snprintf(buf, sizeof(buf), "%"PRIu16".%"PRIu16".%s\n",
 			 TINYIIOD_VERSION_MAJOR,
 			 TINYIIOD_VERSION_MINOR,
 			 TINYIIOD_VERSION_GIT);


### PR DESCRIPTION
`CMakeLists.txt` defines `TINYIIOD_VERSION_GIT` as a string, but `Makefile` defines it as an integer. This causes the following warning when building with cmake.

    home/david/work/bl/libtinyiiod/parser.c: In function ‘tinyiiod_parse_string’:
    /home/david/work/bl/libtinyiiod/parser.c:232:44: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 6 has type ‘char *’ [-Wformat=]
    232 |                 snprintf(buf, sizeof(buf), "%"PRIu16".%"PRIu16".%07x\n",
        |                                            ^~~
    /home/david/work/bl/libtinyiiod/parser.c:232:68: note: format string is defined here
    232 |                 snprintf(buf, sizeof(buf), "%"PRIu16".%"PRIu16".%07x\n",
        |                                                                 ~~~^
        |                                                                    |
        |                                                                    unsigned int
        |                                                                 %07s

Since the output of `git rev-parse --short HEAD` is not guaranteed to be to be 7 digits, it makes more sense to keep it as a string as it was originally. So the format string is changed to `%s` and the Makefile is modified to define the macro as a string literal.

Fixes: https://github.com/analogdevicesinc/libtinyiiod/commit/122f164b1a373c2d208a210133f41889f6593f69